### PR TITLE
feat: add subgraph for features, techStack, tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,12 @@ make run IDEA='task management app for developers'
 
 ## Graph
 
-To dump the LangGraph mermaid, run:
+To dump the LangGraph mermaid diagram, run:
 ```sh
 make dump-graph
 ```
 
+Old graph:
 ```mermaid
 ---
 config:
@@ -44,6 +45,30 @@ graph TD;
 	idea_curator -. &nbsp;continue&nbsp; .-> spec_writer;
 	spec_writer -. &nbsp;end&nbsp; .-> __end__;
 	spec_writer -. &nbsp;continue&nbsp; .-> evaluator;
+	classDef default fill:#f2f0ff,line-height:1.2
+	classDef first fill-opacity:0
+	classDef last fill:#bfb6fc
+```
+
+New graph (top-level; each node is actually a sub graph):
+```mermaid
+---
+config:
+  flowchart:
+    curve: linear
+---
+graph TD;
+	__start__([<p>__start__</p>]):::first
+	requirement_analysis(requirement_analysis)
+	techstack_discovery(techstack_discovery)
+	task_creation(task_creation)
+	log_tasks(log_tasks)
+	__end__([<p>__end__</p>]):::last
+	__start__ --> requirement_analysis;
+	requirement_analysis --> techstack_discovery;
+	task_creation --> log_tasks;
+	techstack_discovery --> task_creation;
+	log_tasks --> __end__;
 	classDef default fill:#f2f0ff,line-height:1.2
 	classDef first fill-opacity:0
 	classDef last fill:#bfb6fc

--- a/makeitreal/cli2.py
+++ b/makeitreal/cli2.py
@@ -21,7 +21,6 @@ def idea(
 ) -> None:
     """Analyze and structure a product idea using the IdeaCurator agent."""
 
-    print("foo")
     if verbose:
         console.print("[dim]Processing idea: {description}[/dim]")
 

--- a/makeitreal/dump_graph.py
+++ b/makeitreal/dump_graph.py
@@ -1,12 +1,11 @@
 import typer
 
-from .graph import IdeationWorkflow
+from .graph2 import IdeationWorkflow
 
 app = typer.Typer(help="Dump workflow graph")
 
 
 @app.command()
 def dump() -> None:
-    """Dump the AI workflow graph."""
-    diagram = IdeationWorkflow().graph.get_graph().draw_mermaid()
-    print(diagram)
+    """Dump the AI workflow graph mermaid diagram."""
+    print(IdeationWorkflow().graph.get_graph().draw_mermaid())

--- a/makeitreal/graph2/state.py
+++ b/makeitreal/graph2/state.py
@@ -1,9 +1,19 @@
 """State definition for LangGraph workflow."""
 
 from typing import Annotated, TypedDict
+from pydantic import BaseModel
 
 from langchain_core.messages import BaseMessage
 from langgraph.graph.message import add_messages
+
+
+class Proposal(BaseModel):
+    """A set of proposed items that is subject to review."""
+
+    proposedItems: list[str] = []
+    changeRequest: str|None = None
+    agentApproved: bool = False
+    humanApproved: bool = False
 
 
 class WorkflowState(TypedDict):
@@ -11,10 +21,6 @@ class WorkflowState(TypedDict):
 
     messages: Annotated[list[BaseMessage], add_messages]
     idea: BaseMessage
-    features : list[str]
-    featureListApproved: bool
-    techStack: list[str]
-    techStackApproved: bool
-    changeRequest: str
-    tasks: list[str]
-    error: str
+    features : Proposal
+    techStack: Proposal
+    tasks: Proposal


### PR DESCRIPTION
Add a sub graph for each of features, tech stack and tasks.

(But there are still neither real LLM calls nor human-in-the-loop - just random approvals.)

Example log:
```
$ docker compose exec make-it-real uv run makeitreal2 "task management app for developers"
╭──────────────────────────────────────────────────────────────────────────────╮
│ 🧠 Analyzing your product idea...                                            │
╰──────────────────────────────────────────────────────────────────────────────╯
features requirement analysis
features review by agent
features review by human
techStack requirement analysis
techStack review by agent
techStack review by human
techStack requirement analysis
techStack review by agent
techStack review by human
tasks requirement analysis
tasks review by agent
tasks requirement analysis
tasks review by agent
tasks requirement analysis
tasks review by agent
tasks requirement analysis
tasks review by agent
tasks review by human
TASKS:
* tasks item 1
* tasks item 2
* tasks item 3
* tasks item 4
* tasks item 5
```